### PR TITLE
feat: removed lightbox2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,7 @@ Instead of using an external application, this gives us the ability to use
 just the webserver's capabilities to generate beautiful directory listings.
 
 This theme provides a simple, flat interface based on
-[Bootstrap 5](https://getbootstrap.com), [Font Awesome](https://fontawesome.com)
-and (for easy navigation in galleries)
-[lightbox2](http://lokeshdhakar.com/projects/lightbox2/). In combination with
-the browser's preview capability, accessing the majority of files should be
-possible, giving the user easy access without a single line of server-side
-dynamic code.
+[Bootstrap 5](https://getbootstrap.com) and [Font Awesome](https://fontawesome.com).
 
 ## Prerequisites
 A fontawesome key is required for the icons. \

--- a/layout/footer.html
+++ b/layout/footer.html
@@ -18,7 +18,6 @@
     generateBreadcrumbs();
     generateList();
   </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/js/lightbox-plus-jquery.min.js"></script>
 </body>
 
 </html>

--- a/layout/header.html
+++ b/layout/header.html
@@ -7,10 +7,8 @@
 
   <title>File Browser</title>
 
-  <script type="text/javascript" src="https://kit.fontawesome.com/c3cedb944a.js" crossorigin="anonymous"></script>
-
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/css/lightbox.min.css">
+  <script type="text/javascript" src="https://kit.fontawesome.com/c3cedb944a.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="/theme/theme.css">
 
   <script type="text/javascript" src="/theme/js/breadcrumbs.js"></script>

--- a/layout/js/list.js
+++ b/layout/js/list.js
@@ -237,10 +237,5 @@ function generateList()
       row.cells[1].classList.add('col', 'filename');
       row.cells[2].classList.add('col-auto', 'd-none', 'd-md-table-cell');
       row.cells[3].classList.add('col-auto', 'd-none', 'd-md-table-cell');
-
-      /* If the file is a picture, add the data attribute for lightbox2, so one
-       * is able to easily navigate through the pictures. */
-      if (filetype == 'image')
-        row.cells[1].children[0].setAttribute('data-lightbox', 'roadtrip');
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "GPLv3",
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.5.2",
-        "bootstrap": "5.3.3",
-        "lightbox2": "2.11.4"
+        "bootstrap": "5.3.3"
       },
       "devDependencies": {
         "less": "4.2.0",
@@ -212,11 +211,6 @@
       "engines": {
         "node": ">=0.4.2"
       }
-    },
-    "node_modules/lightbox2": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/lightbox2/-/lightbox2-2.11.4.tgz",
-      "integrity": "sha512-Fof7RJFWV3Fe4CWTjpto30h04Led97nRStFNLaUD/VrlEs72r7LF9WMndENYvU2e4o8WboSuy+dmetXSKSnQ2Q=="
     },
     "node_modules/make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "license": "GPLv3",
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.5.2",
-    "bootstrap": "5.3.3",
-    "lightbox2": "2.11.4"
+    "bootstrap": "5.3.3"
   },
   "devDependencies": {
     "less": "4.2.0",


### PR DESCRIPTION
Image preview is not really something i need.
Besides lightbox2 isnt really maintained: https://github.com/lokesh/lightbox2/blob/dev/ROADMAP.md#v2x---maintenance-mode

Use lightgallery instead
https://github.com/3z3qu13l/nginx-fancyindex-flat-theme/pull/1

Or a more advanced browser like
- [filebrowser](https://github.com/filebrowser/filebrowser)
- [nextcloud](https://github.com/nextcloud)
- [owncloud](https://doc.owncloud.com/server/next/admin_manual/installation/manual_installation/manual_installation.html)